### PR TITLE
Fix klusolve install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,7 @@ target_compile_definitions(OpenDSSC PRIVATE
 	_D2C_SYSFILE_H_LONG_IS_INT64
 	_COMPLEX_DEFINED
 )
+include(GNUInstallDirs)
 endif()
 
 target_include_directories(OpenDSSC PRIVATE
@@ -452,4 +453,4 @@ target_link_libraries(OpenDSSC
 endif()
 
 # TODO: Add tests and install targets if needed.
-install (TARGETS OpenDSSC DESTINATION "openDSSX/bin")
+install (TARGETS OpenDSSC klusolve_all)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,3 +454,4 @@ endif()
 
 # TODO: Add tests and install targets if needed.
 install (TARGETS OpenDSSC klusolve_all)
+include(CPack)


### PR DESCRIPTION
This installs the needed `klusolve_all` library, adds CPack to allow for the user to create a package (e.g. with `cmake --build build -t package`) and removes the explicit destination directory to install the main executable in favor of using GNUInstallDirs for the Linux version.  The install destination is settable from the command line anyway or via CMake presets, by setting the value of CMAKE_BUILD_PREFIX.  This results in a usable `.sh` installer under Linux and still allows Windows users to explicitly set the installation directory for both the executable and the library.